### PR TITLE
Update version requirements for cocur/slugify

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     },
     "require": {
         "php": ">=5.3",
-        "cocur/slugify": "1.*"
+        "cocur/slugify": "^1.0|^2.0|^3.0|^4.0"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
At this moment library can't be properly installed in a case if `cocur/slugify` is also installed as dependency because [current requirement](https://github.com/tgalopin/simhashphp/blob/d51acef2e2f6c1d9ab74f992806432c859e37282/composer.json#L18) is simply `1.*` while [current version](https://github.com/cocur/slugify/releases) is `4.0`

Since even 4.0 is [backward compatible](https://github.com/cocur/slugify/blob/3f1ffc300f164f23abe8b64ffb3f92d35cec8307/src/Slugify.php#L100-L107) with 1.x - it is safe to include versions up to 4.x as acceptable versions, allowing proper install of this library.